### PR TITLE
Fixes Android Stub! Exception

### DIFF
--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantTaskHandler.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantTaskHandler.groovy
@@ -81,7 +81,7 @@ class VariantTaskHandler {
     Copy copyTask = createResourcesCopyTask()
     Task processTestResourcesTask = project.tasks.getByName(variant.processResourcesTaskName)
     processTestResourcesTask.dependsOn(copyTask)
-    testTask.classpath = project.files(bootClasspath).plus(variant.runpath)
+    testTask.classpath = variant.runpath.plus(project.files(bootClasspath))
     //set the location of the class files of the tests to run
     testTask.testClassesDir = testCompileTask.destinationDir
     testTask.group = JavaBasePlugin.VERIFICATION_GROUP


### PR DESCRIPTION
Switched the order of the classpath in VariantTaskHandler.
Bootclasspath now comes last.

closes #15
