### PR TITLE
the directory where the android plugin outputs the merged resoruces has changed

### DIFF
--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
@@ -202,7 +202,7 @@ public class VariantWrapper {
    * @return the path where the resources are merged by android plugin
    */
   private static String initRealMergedResourcesDir(Project project, ApplicationVariant variant) {
-    return "$project.buildDir${File.separator}res${File.separator}all${File.separator}$variant.dirName"
+    return "$project.buildDir${File.separator}intermediates${File.separator}res${File.separator}$variant.dirName"
   }
 
   /**


### PR DESCRIPTION
In the android plugin `0.11.0` the build directory for merged resources has changed. This broke the copy tasks so test wouldn't be able to find any resources.
