### PR TITLE
IDE support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
   compile 'com.android.tools.build:gradle:0.11.1'
+  compile 'me.tatarka.androidunittest:android-unit-test-model:1.0'
 
   testCompile 'junit:junit:4.10'
   testCompile 'org.easytesting:fest-assert-core:2.0M10'

--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/ModelBuilder.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/ModelBuilder.groovy
@@ -1,0 +1,95 @@
+package com.jcandksolutions.gradle.androidunittest
+import me.tatarka.androidunittest.model.AndroidUnitTest
+import me.tatarka.androidunittest.model.AndroidUnitTestModel
+import me.tatarka.androidunittest.model.Variant
+import me.tatarka.androidunittest.model.VariantModel
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ProjectDependency
+
+class ModelBuilder {
+    private String RPackageName
+    private List<VariantBuilder> variants = []
+
+    public void RPackageName(String name) {
+        RPackageName = name
+    }
+
+    public void addSourceSet(VariantWrapper variantWrapper) {
+        variants.add(new VariantBuilder(variantWrapper))
+    }
+
+    public void addConfig(Set<String> names, Configuration config) {
+        variants.find { it.matches(names) }?.addDependencies(config)
+    }
+
+    public void addConfig(Configuration config) {
+        variants*.addDependencies(config)
+    }
+
+    public AndroidUnitTest build() {
+        return new AndroidUnitTestModel(RPackageName, variants*.build())
+    }
+
+    private class VariantBuilder {
+        private final List<String> flavors;
+        private final String buildType;
+        private final String name;
+        private final File manifest;
+        private final Set<File> sourceDirectories;
+        private final File resourcesDirectory;
+        private final File assetsDirectory;
+        private final File compileDestinationDir;
+        private final Set<File> javaDependencies = new HashSet<File>();
+        private final Set<String> projectDependencies = new HashSet<String>();
+
+        VariantBuilder(VariantWrapper v) {
+            flavors = v.flavorNames
+            buildType = v.buildType
+            name = buildName(flavors, buildType)
+            manifest = v.mergedManifest
+            sourceDirectories = v.sourceDirs
+            resourcesDirectory = v.mergedResourcesDir
+            assetsDirectory = v.mergedAssetsDir
+            compileDestinationDir = v.compileDestinationDir
+        }
+
+        boolean matches(Set<String> names) {
+            for (String name : names)  {
+                if (!(buildType == name || flavors.contains(name))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void addDependencies(Configuration config) {
+            javaDependencies.addAll(config.files)
+
+            for (Dependency dependency : config.getAllDependencies()) {
+                if (dependency instanceof ProjectDependency) {
+                    projectDependencies.add(dependency.dependencyProject.path);
+                }
+            }
+        }
+
+        private static String buildName(List<String> flavors, String buildType) {
+            if (flavors.isEmpty()) {
+                buildType;
+            } else {
+                Iterator<String> flavorItr = flavors.iterator();
+                StringBuilder sb = new StringBuilder(flavorItr.next());
+                while (flavorItr.hasNext()) {
+                    sb.append(flavorItr.next().capitalize());
+                }
+                sb.append(buildType.capitalize());
+                sb.toString();
+            }
+        }
+
+        Variant build() {
+            return new VariantModel(name, manifest, sourceDirectories, resourcesDirectory, assetsDirectory,
+                    javaDependencies, projectDependencies, compileDestinationDir)
+        }
+    }
+}

--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantTaskHandler.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantTaskHandler.groovy
@@ -16,12 +16,14 @@ class VariantTaskHandler {
   private String bootClasspath
   private Project project
   private String packageName
+  private Task testClassesTask
 
-  public VariantTaskHandler(VariantWrapper variant, Project project, String bootClasspath, String packageName) {
+  public VariantTaskHandler(VariantWrapper variant, Project project, String bootClasspath, String packageName, Task testClassesTask) {
     this.variant = variant
     this.project = project
     this.bootClasspath = bootClasspath
     this.packageName = packageName
+    this.testClassesTask = testClassesTask
   }
 
   /**
@@ -73,6 +75,7 @@ class VariantTaskHandler {
     Task classesTask = configureClassesTask()
     //make the test depend on the classesTask that handles the compilation and resources of tests
     testTask.dependsOn(classesTask)
+    testClassesTask.dependsOn(classesTask)
     //Clear the inputs because JavaBasePlugin adds an empty dir which makes it crash.
     testTask.inputs.sourceFiles.from.clear()
     JavaCompile testCompileTask = configureTestCompileTask()

--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
@@ -48,6 +48,7 @@ public class VariantWrapper {
     resourcesCopyTaskName = initResourcesCopyTaskName(completeName)
     realMergedResourcesDir = initRealMergedResourcesDir(project, variant)
     processResourcesTaskName = initProcessResourcesTaskName(completeName)
+
     log("build type: $buildType")
     log("flavors: $flavorName")
     log("variant name: $completeName")
@@ -263,6 +264,14 @@ public class VariantWrapper {
     return variant.buildType.name.capitalize()
   }
 
+  public List<String> getFlavorNames() {
+    return variant.productFlavors*.name
+  }
+
+  public String getBuildType() {
+    return variant.buildType.name
+  }
+
   /**
    * Gets the dir name of the variant. Example: freeBeta/debug
    * @return the dir name of the variant.
@@ -365,5 +374,9 @@ public class VariantWrapper {
    */
   public String getProcessResourcesTaskName() {
     return processResourcesTaskName
+  }
+
+  public Set<File> getSourceDirs() {
+    return sourceSet.allJava.srcDirs
   }
 }


### PR DESCRIPTION
I created an [Android Studo plugin](https://github.com/evant/android-studio-unit-test-plugin) which requires a gradle plugin to provide a model for the ide to read. I don't expect you to merge this pull request as-is because it dependes on a local library that provides the interface between the plugin and the ide. This [library](https://github.com/evant/android-studio-unit-test-plugin/tree/master/android-unit-test-model) needs to be hosted seperatly on maven central so that the gradle plugin can be updated independently. I'm not sure if you want to pull this in and maintain it yourself, or have me do it.
