### PR TITLE
Use the new gradle android model to clean things up.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   compile gradleApi()
   compile localGroovy()
-  compile 'com.android.tools.build:gradle:0.11.1'
+  compile 'com.android.tools.build:gradle:0.12.1'
   compile 'me.tatarka.androidunittest:android-unit-test-model:1.0'
 
   testCompile 'junit:junit:4.10'

--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/ModelBuilder.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/ModelBuilder.groovy
@@ -21,12 +21,16 @@ class ModelBuilder {
     variants.add(new VariantBuilder(variantWrapper))
   }
 
-  public void addConfig(Set<String> names, Configuration config) {
-    variants.find { it.matches(names) }?.addDependencies(config)
-  }
-
   public void addConfig(Configuration config) {
     variants*.addDependencies(config)
+  }
+
+  public void addBuildTypeConfig(String name, Configuration config) {
+    variants.findAll { it.buildType == name }*.addDependencies(config)
+  }
+
+  public void addProductFlavorConfig(String name, Configuration config) {
+    variants.findAll { it.flavors.contains(name) }*.addDependencies(config)
   }
 
   public AndroidUnitTest build() {


### PR DESCRIPTION
This removes a bunch of errounous configurations that were created like
'testAndroidTestCompile'.

As a bonus, also now works without defining applicationId in defaultConfig by
looking in the manifest if it's not defined
