### PR TITLE
resolve source and javadoc artifacts using the gradle api

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.1-all.zip


### PR DESCRIPTION
This uses some of the lower-level gradle api to properly resolve javadoc and source artifacts. This way you don't run into problems if they are not found, and it may be smarter at finding them. Downside is it requires gradle 2.0+, though it looks like the android plugin is moving in that direction as well.

Like the current implementation, it only downloads from your top-level dependencies. However, I didn't quite figure out how to not pull in your app dependencies when you ask for the test ones since the configurations are dependent on each other. Maybe moving this step before calling `extendsFrom` on the test configuration would work, or maybe some smart filtering could be done with the artifact set.

You may notice that it is using the internal gradle class `org.gradle.api.internal.artifacts.component.DefaultModuleComponentIdentifier`. I think that there is little risk that this class will change, but if we can just duplicate it locally if that makes you feel better. It's just a POJO with about the simplest implementation you can think of.
