### PR TITLE
Fix a Gradle build error by making the examples part of the root project

### DIFF
--- a/example/settings.gradle
+++ b/example/settings.gradle
@@ -1,1 +1,0 @@
-include ':exampleLibrary', ':exampleApp'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,5 @@
+include ':exampleApp'
+include ':exampleLibrary'
+
+project(':exampleApp').projectDir = file('example/exampleApp')
+project(':exampleLibrary').projectDir = file('example/exampleLibrary')


### PR DESCRIPTION
This fixes:

Error:Gradle: Project 'exampleApp' not found in root project
'android-unit-test'.
