### PR TITLE
Make test source location configurable via sourceSet

### DIFF
--- a/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
+++ b/src/main/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapper.groovy
@@ -62,9 +62,14 @@ public abstract class VariantWrapper {
    * Configures the SourceSet with the Sourcepath, Classpath and Runpath.
    */
   public void configureSourceSet() {
-    //Add standard resources directory
-    sourceSet.resources.srcDirs(mProject.file("src${File.separator}test${File.separator}resources"))
-    sourceSet.java.srcDirs = testsSourcePath
+    // Add default directories if nothing is defined
+    if (sourceSet.resources != null && sourceSet.resources.srcDirs.size() == 0) {
+      sourceSet.resources.srcDirs(mProject.file("src${File.separator}test${File.separator}resources"))
+    }
+    if (sourceSet.java != null && sourceSet.java.srcDirs.size() == 0) {
+      sourceSet.java.srcDirs = testsSourcePath
+    }
+
     sourceSet.compileClasspath = classpath
     sourceSet.runtimeClasspath = runPath
     //Add this SourceSet to the classes task for compilation
@@ -263,6 +268,10 @@ public abstract class VariantWrapper {
    * @return The test SourceSet.
    */
   protected SourceSet getSourceSet() {
+    if (mSourceSet == null) {
+      JavaPluginConvention javaConvention = mProject.convention.getPlugin(JavaPluginConvention)
+      mSourceSet = javaConvention.sourceSets.findByName("unitTest")
+    }
     if (mSourceSet == null) {
       JavaPluginConvention javaConvention = mProject.convention.getPlugin(JavaPluginConvention)
       mSourceSet = javaConvention.sourceSets.create("test$completeName")

--- a/src/test/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapperTest.groovy
+++ b/src/test/groovy/com/jcandksolutions/gradle/androidunittest/VariantWrapperTest.groovy
@@ -56,6 +56,7 @@ public class VariantWrapperTest {
   private File mMergeAssetsOutputDir
   private FileCollection mTestClasspath
   private MockProvider mProvider
+  private SourceSetContainer mSourceSets
 
   @Before
   public void setUp() {
@@ -64,9 +65,9 @@ public class VariantWrapperTest {
     mConfigurations = mProvider.provideConfigurations()
     String bootClasspathString = mProvider.provideBootClasspath()
     Convention convention = mock(Convention.class)
-    SourceSetContainer sourceSets = mock(DefaultSourceSetContainer.class)
+    mSourceSets = mock(DefaultSourceSetContainer.class)
     Instantiator instantiator = mock(Instantiator.class)
-    when(instantiator.newInstance(DefaultSourceSetContainer.class, null, null, instantiator)).thenReturn(sourceSets)
+    when(instantiator.newInstance(DefaultSourceSetContainer.class, null, null, instantiator)).thenReturn(mSourceSets)
     JavaPluginConvention javaConvention = new JavaPluginConvention(mock(ProjectInternal.class), instantiator);
     mSourceSet = mock(SourceSet.class)
     mVariant = mock(ApplicationVariant.class)
@@ -117,7 +118,7 @@ public class VariantWrapperTest {
     when(mVariant.javaCompile).thenReturn(androidJavaCompileTask)
     when(mVariant.dirName).thenReturn("variantDirName")
     when(mVariant.mergeAssets).thenReturn(mergeAssets)
-    when(sourceSets.create("testFreePaidDebug")).thenReturn(mSourceSet)
+    when(mSourceSets.create("testFreePaidDebug")).thenReturn(mSourceSet)
     when(mSourceSet.resources).thenReturn(mResources)
     when(mSourceSet.java).thenReturn(mJava)
     when(mSourceSet.classesTaskName).thenReturn(mClassesTaskName)
@@ -156,6 +157,19 @@ public class VariantWrapperTest {
     assertThat(fileCollectionCaptor.value.asPath).isEqualTo("build${File.separator}test-classes${File.separator}variantDirName".toString())
     verify(mSourceSet).runtimeClasspath = mRunpath
     verify(mSourceSet).compiledBy(mClassesTaskName)
+  }
+
+  @Test
+  public void testConfigureSourceSetProvided() {
+    SourceSet providedSourceSet = mock(SourceSet.class)
+    SourceDirectorySet java = mock(SourceDirectorySet.class)
+    Set<File> srcDirs = ["project1/src"]
+    when(java.srcDirs).thenReturn(srcDirs)
+    when(providedSourceSet.java).thenReturn(java)
+    when(mSourceSets.findByName("unitTest")).thenReturn(providedSourceSet)
+
+    mTarget.configureSourceSet()
+    assertThat(mTarget.sourceSet).isEqualTo(providedSourceSet)
   }
 
   @Test


### PR DESCRIPTION
Suggestion for fixing https://github.com/JCAndKSolutions/android-unit-test/issues/32
Gradle code to use this would look like:

```
androidUnitTest {
    downloadDependenciesSources false
    downloadTestDependenciesSources false
    sourceSets {
        unitTest {
            java.srcDirs = ['../testproject/src']
        }
    }
}
```

The fixed paths currently used would still be applied no corresponding source set is provided.
